### PR TITLE
Fix page title ios

### DIFF
--- a/ImageCropper.Maui/Platforms/iOS/PlatformImageCropper.cs
+++ b/ImageCropper.Maui/Platforms/iOS/PlatformImageCropper.cs
@@ -54,11 +54,7 @@ namespace ImageCropper.Maui
 
             UIApplication.SharedApplication.KeyWindow.RootViewController.PresentViewController(cropViewController, true, null);
 
-            if (!string.IsNullOrWhiteSpace(imageCropper.PageTitle) && cropViewController.TitleLabel != null)
-            {
-                UILabel titleLabel = cropViewController.TitleLabel;
-                titleLabel.Text = imageCropper.PageTitle;
-            }
+            cropViewController.Title = imageCropper.PageTitle;
         }
         private static async void Finalize(ImageCropper imageCropper, UIImage image)
         {

--- a/ImageCropper.Maui/Platforms/iOS/PlatformImageCropper.cs
+++ b/ImageCropper.Maui/Platforms/iOS/PlatformImageCropper.cs
@@ -54,7 +54,10 @@ namespace ImageCropper.Maui
 
             UIApplication.SharedApplication.KeyWindow.RootViewController.PresentViewController(cropViewController, true, null);
 
-            cropViewController.Title = imageCropper.PageTitle;
+            if(imageCropper.PageTitle != null && imageCropper.PageTitle.Length > 0)
+            {
+                cropViewController.Title = imageCropper.PageTitle;
+            }
         }
         private static async void Finalize(ImageCropper imageCropper, UIImage image)
         {


### PR DESCRIPTION
I noticed that even though the title label's text was set on iOS, at least in the code, no title was displayed.
Debugging a local build showed that the text setting code was never reached because the Titlelabel was null.
The TitleLabel is get only, so I coculdn't create my own Title Label.
However, setting TOCropViewController.Title is written in such a way, that it creates a label only when necesarry.
A quote from [TOCropVIewController](https://github.com/TimOliver/TOCropViewController/blob/a942414508012b13102f776eb65dac655f31cabb/Objective-C/TOCropViewController/TOCropViewController.m#L370): "If there is no title text, inset the top of the content as high as possible"

TOCropViewController tries to take up as much space on the screen as possible, so when no Title text is set, no label is created in order to maximize space.
My code change replaces 

```csharp
if (!string.IsNullOrWhiteSpace(imageCropper.PageTitle) && cropViewController.TitleLabel != null)
 {
      UILabel titleLabel = cropViewController.TitleLabel;
      titleLabel.Text = imageCropper.PageTitle;
 }
```

With:
```csharp
if(imageCropper.PageTitle != null && imageCropper.PageTitle.Length > 0)
{
    cropViewController.Title = imageCropper.PageTitle;
}
```

as this is all that is needed to make the title display on screen.